### PR TITLE
Add filter for modifying the cart item data before sending the insight

### DIFF
--- a/includes/cart/class-dotdigital-woocommerce-cart-insight.php
+++ b/includes/cart/class-dotdigital-woocommerce-cart-insight.php
@@ -84,7 +84,7 @@ class Dotdigital_WooCommerce_Cart_Insight {
 			$line_item_data['unit_price'] = round( (float) $product->get_regular_price(), 2 );
 			$line_item_data['sale_price'] = round( $this->get_product_sale_price( $product ), 2 );
 
-			$line_items[] = $line_item_data;
+			$line_items[] = apply_filters( 'dotdigital_modify_line_item_data', $line_item_data, $cart_item );
 		}
 
 		$data['line_items'] = $line_items;

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,9 @@ For more detailed information on installation, please see our <a href="https://s
 
 == Changelog ==
 
+= Unreleased =
+- Add filter for modifying the cart item data before sending the insight. This solves a problem with the Name your price plugin, which returns the wrong price.
+
 = 1.3.4 =
 
 **Improvements**


### PR DESCRIPTION
- Added filter for comparing it to the cart item data and modifying it before sending the insight. This solves a problem with the Name your price plugin, which returns the wrong price in the cart insight.
